### PR TITLE
Fix bug, render all links in nav menu on screen for responsive Mobile view

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,8 +135,16 @@ nav .fa-solid {
         cursor: pointer;
     }
 
-    .nav-links ul {
-        padding: 0px 30px;
+    .nav-links ul li {
+        padding: 12px 0;
+    }
+
+    .nav-items {
+      display: block;
+    }
+
+    #menu-btn {
+      background-color: #3652a2;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <li><a href="./pages/about.html">ABOUT</a></li>
             <li><a href="./pages/contact.html">CONTACT US</a></li>
             <li>
-              <button type="button" class="btn btn-outline-light">
+              <button type="button" class="btn btn-outline-light" id="menu-btn">
                 <a href="./pages/sign-up.html" style="all: unset;">GET STARTED</a>
               </button>
             </li>


### PR DESCRIPTION
Currently, while looking at the website in Mobile view, the links in the navbar menu go off screen. This fix renders all of the links in a vertical alignment so that they are all on screen @ a max width of 875px.